### PR TITLE
[VideoRecorder] Fixes for Android and iOS (#38, #41, #21) + improvments in logic + better Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Option object can be given to the constructor of `VideoRecorder` or as `VideoRec
 * **hd?: boolean** - If true, highest quality of device, if false MMS quality (default: `false`)
 * **saveToGallery?: boolean** - Enable to save the video in the device Gallery, otherwise it will be store within the sandbox of the app (default: `false`)
 * **duration?: number** - Limit the duration of the video, 0 for unlimited (default: `0`)
-* **position?: 'front' | 'back'** -
+* **position?: 'front' | 'back' | 'none'** - Force which device camera should be used, `'none'` for no preferences (default: `none`)
 
 Additionnal parameters for Android:
 

--- a/README.md
+++ b/README.md
@@ -5,56 +5,88 @@
 ## Install
 `tns plugin add nativescript-videorecorder`
 
-### Usage
+## QuickStart
 
-### Android
+#### JavaScript
 ```js
-var vr = require("nativescript-videorecorder");
-var videorecorder = new vr.VideoRecorder();
+var vr = require('nativescript-videorecorder');
+
 var options = {
-    saveToGallery:true, //default false | optional
-    duration:30, //(seconds) default no limit | optional
-    format:'mp4', //allows videos to be played on android devices | optional | recommended for cross platform apps
-    size:10, //(MB) default none | optional #android
-    hd:true, //default  false low res | optional
-    explanation:"Why do i need this permission" //optional on api 23 #android
+    saveToGallery: true,
+    duration: 30,
+    format: 'mp4',
+    size: 10,
+    hd: true,
+    explanation: 'Why do i need this permission'
 }
 
-videorecorder.record(options)
-.then((data)=>{
-    console.log(data.file)
+var videorecorder = new vr.VideoRecorder(options);
+
+videorecorder.record().then((data)=>{
+  console.log(data.file)
+}).catch((err)=>{
+  console.log(err)
 })
-.catch((err)=>{
+```
+
+#### TypeScript
+```ts
+import { VideoRecorder, Options as VideoRecorderOptions } from 'nativescript-videorecorder';
+
+const options: VideoRecorderOptions = {
+    hd: true
+    saveToGallery: true
+}
+const videorecorder = new VideoRecorder(options)
+
+videorecorder.record().then((data) => {
+    console.log(data.file)
+}).catch((err) => {
     console.log(err)
 })
 ```
 
+## VideoRecorder
 
-```js
-var vr = require("nativescript-videorecorder");
-var videorecorder = new vr.VideoRecorder();
-var options = {
-    saveToGallery:true, //default false | optional
-    duration:30, //(seconds) default no limit | optional
-    size:10, //(MB) default none | optional,
-    format:'mp4', //allows videos to be played on android devices | optional | recommended for cross platform apps
-    hd:true, //default  false low res | optional
-}
-videorecorder.record(options)
-.then((data)=>{
-    console.log(data.file)
-})
-.catch((err)=>{
-    console.log(err)
-})
-```
+### Options
 
-##### AdvancedVideoView
+Option object can be given to the constructor of `VideoRecorder` or as `VideoRecorder::record` parameter (as an override).
+
+* **hd?: boolean** - If true, highest quality of device, if false MMS quality (default: `false`)
+* **saveToGallery?: boolean** - Enable to save the video in the device Gallery, otherwise it will be store within the sandbox of the app (default: `false`)
+* **duration?: number** - Limit the duration of the video, 0 for unlimited (default: `0`)
+* **position?: 'front' | 'back'** -
+
+Additionnal parameters for Android:
+
+* **size?: number** - Limit the size of the video, 0 for unlimited (default: `0`)
+* **explanation?: string** - Why permissions should be accepted, optional on api > 23
+
+Additionnal parameters for iOS:
+
+* **format?: 'default' | 'mp4'** - allows videos to be played on android devices (default: `'default'`) recommended for cross platform apps
+
+### VideoRecorder attributes:
+
+* **options: Options** Option object (see above section), can be set from the constructor
+
+### VideoRecorder methods:
+
+* **record(options?: Options): Promise<{ file?: string } >** Return a Promise with an object containing the filepath as `file` key. It may not be there if the video has been saved to the gallery. An optional `options` parameter can be given to override instance `options`.
+* **requestPermissions(): Promise<void>** Return a Promise, resolved if permissions are OK (ask for permissions if not), rejected if user didn't have accepted the permissions. This method is implicitely called by `record()`
+
+Promises can be rejected with:
+
+* `{ event: 'denied'}` - Permissions have not been accepted
+* `{ event: 'cancelled'}` - Video capture have been canceled
+* `{ event: 'failed'}` - Generic error
+
+
+## AdvancedVideoView
 
 ```xml
 <Page xmlns="http://schemas.nativescript.org/tns.xsd" xmlns:recorder="nativescript-videorecorder/advanced">
 <recorder:AdvancedVideoView quality="highest" cameraPosition="front" id="camera"/>
-
 ```
 
 ```ts
@@ -62,7 +94,7 @@ const advancedView = page.getViewById("camera");
 advancedView.startRecording();
 ```
 
-## Api
+### Api
 
 | Method                  | Default  | Type    | Description                                           |
 | ----------------------- | -------- | ------- | ----------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ Additionnal parameters for iOS:
 
 ### VideoRecorder methods:
 
-* **record(options?: Options): Promise<{ file?: string } >** Return a Promise with an object containing the filepath as `file` key. It may not be there if the video has been saved to the gallery. An optional `options` parameter can be given to override instance `options`.
+* **record(options?: Options): Promise<{ file?: string } >** Return a Promise with an object containing the filepath as `file` key. It may not be there if the video has been saved to the gallery. An optional `options` parameter can be given to override instance `options`, this is deprecated.
 * **requestPermissions(): Promise<void>** Return a Promise, resolved if permissions are OK (ask for permissions if not), rejected if user didn't have accepted the permissions. This method is implicitely called by `record()`
+* **isAvailable(): boolean** Check if device has a camera and is compatible with what has been set in options
 
-Promises can be rejected with:
+Promises above can be rejected with:
 
 * `{ event: 'denied'}` - Permissions have not been accepted
 * `{ event: 'cancelled'}` - Video capture have been canceled

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -4,7 +4,7 @@ import { HelloWorldModel } from './main-view-model';
 import * as fs from 'tns-core-modules/file-system';
 let page;
 let vm = new HelloWorldModel();
-import { VideoRecorder } from 'nativescript-videorecorder';
+import { VideoRecorder, CameraPosition } from 'nativescript-videorecorder';
 import { topmost } from 'tns-core-modules/ui/frame';
 
 export function navigatingTo(args) {}
@@ -15,16 +15,28 @@ export function loaded(args: pages.NavigatedData) {
   page.bindingContext = vm;
 }
 
+const vr = new VideoRecorder({ hd: true, position: CameraPosition.NONE });
+vm.set('position', CameraPosition.NONE);
+
 export function openAdvancedCameraView(event) {
   topmost().navigate('advanced-page');
 }
 export function recordVideo() {
-  const vr = new VideoRecorder();
-  vr.record({ hd: true }).then(data => {
+  vm.set('error', '');
+  vr.record().then(data => {
     if (data && data.file) {
       vm.set('selectedVideo', data.file);
     }
+  }).catch((err) => {
+    vm.set('error', err.event || err.message);
   });
 }
 
-export function toggleCamera() {}
+export function toggleCamera() {
+  vr.options.position = vr.options.position === CameraPosition.BACK
+    ? CameraPosition.FRONT
+    : vr.options.position === CameraPosition.FRONT
+      ? CameraPosition.NONE
+      : CameraPosition.BACK;
+  vm.set('position', vr.options.position);
+}

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -7,11 +7,11 @@
     <Button text="Open Advanced Camera View" tap="openAdvancedCameraView"/>
     <StackLayout verticalAlignment="center">
       <Button text="Toggle Camera" tap="toggleCamera"/>
+      <Label textAlignment="center" text="{{position}}"/>
       <Label textAlignment="center" text="{{duration}}" />
-      <Label text="{{selectedVideo}}"/>
-      <Button text="Preview Video" tap="openPreview"/>
+      <Label text="{{selectedVideo}}" textWrap="true"/>
       <Button text="Record Video" tap="recordVideo"/>
-      <Button text="Stop Recording" tap="stopRecording"/>
+      <Label textAlignment="center" text="{{error}}" color="red" textWrap="true" />
       <VideoPlayer:Video height="100%" src="{{selectedVideo}}" loaded="videoplayerLoaded" finished="videoFinished" autoplay="true" />
     </StackLayout>
   </StackLayout>

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -7,11 +7,7 @@ export class HelloWorldModel extends Observable {
     super();
   }
   recorder(options) {
-    const vr = new VideoRecorder();
-    if (options) {
-      return vr.record(options);
-    } else {
-      return vr.record();
-    }
+    const vr = new VideoRecorder(options);
+    return vr.record();
   }
 }

--- a/src/advanced/advanced-video-view.android.ts
+++ b/src/advanced/advanced-video-view.android.ts
@@ -5,7 +5,6 @@ import { Color } from 'tns-core-modules/color';
 import { View, layout, Property } from 'tns-core-modules/ui/core/view';
 import '../async-await';
 import { device } from 'tns-core-modules/platform/platform';
-import { requestPermissions } from '..';
 import * as app from 'tns-core-modules/application';
 import * as permissions from 'nativescript-permissions';
 import * as utils from 'tns-core-modules/utils/utils';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,18 @@
 
+export interface Options {
+  size?: number,
+  hd?: boolean,
+  saveToGallery?: boolean,
+  duration?: number,
+  explanation?: string,
+  format?: 'default' | 'mp4',
+  position?: CameraPosition,
+}
+
+export type CameraPosition = 'front' | 'back';
+export type VideoFormat = 'default' | 'mp4';
+
 export declare class VideoRecorder {
-  record(options?: any): Promise<any>;
+  record(options?: Options): Promise<any>;
 }
 export declare const requestPermissions: (options: any) => Promise<any>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,18 +4,29 @@ export interface Options {
   saveToGallery?: boolean,
   duration?: number,
   explanation?: string,
-  format?: VideoFormat,
-  position?: CameraPosition,
+  format?: VideoFormatType,
+  position?: CameraPositionType,
 }
 
-export type CameraPosition = 'front' | 'back';
-export type VideoFormat = 'default' | 'mp4';
+export type CameraPositionType = 'front' | 'back';
+export type VideoFormatType = 'default' | 'mp4';
+
+export enum CameraPosition {
+  FRONT = 'front',
+  BACK = 'back',
+}
+
+export enum VideoFormat {
+  DEFAULT = 'default',
+  MP4 = 'mp4',
+}
 
 export declare class VideoRecorder {
   options: Options
   
   constructor(options?: Options);
 
-  public record(): Promise<any>;
+  public record(options?: Options): Promise<any>;
   public requestPermissions(): Promise<any>;
+  public isAvailable(): boolean;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,10 @@ export interface Options {
   position?: CameraPositionType,
 }
 
+export interface RecordResult {
+  file: string,
+}
+
 export type CameraPositionType = 'front' | 'back' | 'none';
 export type VideoFormatType = 'default' | 'mp4';
 
@@ -27,7 +31,7 @@ export declare class VideoRecorder {
   
   constructor(options?: Options);
 
-  public record(options?: Options): Promise<any>;
+  public record(options?: Options): Promise<RecordResult>;
   public requestPermissions(): Promise<any>;
   public isAvailable(): boolean;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,11 +1,10 @@
-
 export interface Options {
   size?: number,
   hd?: boolean,
   saveToGallery?: boolean,
   duration?: number,
   explanation?: string,
-  format?: 'default' | 'mp4',
+  format?: VideoFormat,
   position?: CameraPosition,
 }
 
@@ -13,6 +12,10 @@ export type CameraPosition = 'front' | 'back';
 export type VideoFormat = 'default' | 'mp4';
 
 export declare class VideoRecorder {
-  record(options?: Options): Promise<any>;
+  options: Options
+  
+  constructor(options?: Options);
+
+  public record(): Promise<any>;
+  public requestPermissions(): Promise<any>;
 }
-export declare const requestPermissions: (options: any) => Promise<any>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,12 +8,13 @@ export interface Options {
   position?: CameraPositionType,
 }
 
-export type CameraPositionType = 'front' | 'back';
+export type CameraPositionType = 'front' | 'back' | 'none';
 export type VideoFormatType = 'default' | 'mp4';
 
 export enum CameraPosition {
   FRONT = 'front',
   BACK = 'back',
+  NONE = 'none',
 }
 
 export enum VideoFormat {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,37 +1,6 @@
-export interface Options {
-  size?: number,
-  hd?: boolean,
-  saveToGallery?: boolean,
-  duration?: number,
-  explanation?: string,
-  format?: VideoFormatType,
-  position?: CameraPositionType,
-}
+import { VideoRecorderCommon } from './videorecorder.common'
+export * from './videorecorder.common'
 
-export interface RecordResult {
-  file: string,
-}
+export declare class VideoRecorder extends VideoRecorderCommon {
 
-export type CameraPositionType = 'front' | 'back' | 'none';
-export type VideoFormatType = 'default' | 'mp4';
-
-export enum CameraPosition {
-  FRONT = 'front',
-  BACK = 'back',
-  NONE = 'none',
-}
-
-export enum VideoFormat {
-  DEFAULT = 'default',
-  MP4 = 'mp4',
-}
-
-export declare class VideoRecorder {
-  options: Options
-  
-  constructor(options?: Options);
-
-  public record(options?: Options): Promise<RecordResult>;
-  public requestPermissions(): Promise<any>;
-  public isAvailable(): boolean;
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,0 +1,533 @@
+{
+  "name": "nativescript-videorecorder",
+  "version": "3.0.0-ALPHA.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
+      "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nativescript-permissions": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/nativescript-permissions/-/nativescript-permissions-1.2.3.tgz",
+      "integrity": "sha1-4+ZVRfmP5IjdVXj3/5DrrjCI5wA="
+    },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
+    },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "dev": true,
+      "requires": {
+        "colors": "1.2.1",
+        "pkginfo": "0.4.1",
+        "read": "1.0.7",
+        "revalidator": "0.1.8",
+        "utile": "0.3.0",
+        "winston": "2.1.1"
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "0.0.7"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tns-core-modules": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-3.4.1.tgz",
+      "integrity": "sha512-sz/yTmoW7WyDPpr4JEC+trlfiEI14X365jGF//tMCT/G6ISzANr43wc17fgbGH1UA1XbKzujbAl0xPNssRHVUA==",
+      "dev": true,
+      "requires": {
+        "tns-core-modules-widgets": "3.4.0"
+      }
+    },
+    "tns-core-modules-widgets": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-3.4.0.tgz",
+      "integrity": "sha512-WEtjDRTjjKB+C1NhY1CJSNyhK9DPCYzBgM+yKgq5AmphK/QdQEMAP1U2ttOv8yWWfsvLZGOnzyLCzcyeoG0Gfw==",
+      "dev": true
+    },
+    "tns-platform-declarations": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-3.4.1.tgz",
+      "integrity": "sha512-GCvUvmtZ2Nne9GIppYF5xzUQzYP+KF43R+ce9kFMT1erDP0I6thLrRkLEo8JgAYD7ukMqXAb80MlYMv/VDGSCw==",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.2",
+        "commander": "2.15.0",
+        "diff": "3.5.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.11.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.5.0",
+        "tslib": "1.9.0",
+        "tsutils": "2.22.2"
+      }
+    },
+    "tsutils": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.22.2.tgz",
+      "integrity": "sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.9.0"
+      }
+    },
+    "typescript": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "dev": true
+    },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "dev": true,
+      "requires": {
+        "async": "0.9.2",
+        "deep-equal": "0.2.2",
+        "i": "0.3.6",
+        "mkdirp": "0.5.1",
+        "ncp": "1.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "winston": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "dev": true,
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+          "dev": true
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-videorecorder",
-  "version": "3.0.0-ALPHA.1",
+  "version": "3.0.0-alpha.1",
   "description": "NativeScript videorecording plugin",
   "main": "videorecorder",
   "typings": "index.d.ts",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-videorecorder",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "description": "NativeScript videorecording plugin",
   "main": "videorecorder",
   "typings": "index.d.ts",

--- a/src/platforms/android/AndroidManifest.xml
+++ b/src/platforms/android/AndroidManifest.xml
@@ -4,7 +4,19 @@
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-feature android:name="android.hardware.camera" android:required="false" />
 	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
-	
+
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />
 	<uses-feature android:name="android.hardware.microphone" android:required="false" />
+
+	<application>
+		<provider
+				android:name="android.support.v4.content.FileProvider"
+				android:authorities="${applicationId}.provider"
+				android:exported="false"
+				android:grantUriPermissions="true">
+			<meta-data
+					android:name="android.support.FILE_PROVIDER_PATHS"
+					android:resource="@xml/provider_paths"/>
+		</provider>
+	</application>
 </manifest>

--- a/src/platforms/android/AndroidManifest.xml
+++ b/src/platforms/android/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest
 	xmlns:android="http://schemas.android.com/apk/res/android">
 	<uses-permission android:name="android.permission.CAMERA" />
-	<uses-feature android:name="android.hardware.camera" />
-	<uses-feature android:name="android.hardware.camera.autofocus" />
+	<uses-feature android:name="android.hardware.camera" android:required="false" />
+	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+	
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />
+	<uses-feature android:name="android.hardware.microphone" android:required="false" />
 </manifest>

--- a/src/typings/android.d.ts
+++ b/src/typings/android.d.ts
@@ -1,104 +1,104 @@
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export class BuildConfig {
-				public static DEBUG: boolean;
-				public static APPLICATION_ID: string;
-				public static BUILD_TYPE: string;
-				public static FLAVOR: string;
-				public static VERSION_CODE: number;
-				public static VERSION_NAME: string;
-				public constructor();
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export class BuildConfig {
+        public static DEBUG: boolean;
+        public static APPLICATION_ID: string;
+        public static BUILD_TYPE: string;
+        public static FLAVOR: string;
+        public static VERSION_CODE: number;
+        public static VERSION_NAME: string;
+        public constructor();
+      }
+    }
+  }
 }
 
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export class Camera1 extends co.fitcom.fancycamera.CameraBase {
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export class Camera1 extends co.fitcom.fancycamera.CameraBase {
+      }
+    }
+  }
 }
 
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export class Camera2 extends co.fitcom.fancycamera.CameraBase {
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export class Camera2 extends co.fitcom.fancycamera.CameraBase {
+      }
+    }
+  }
 }
 
 import androidviewTextureView = android.view.TextureView;
 /// <reference path="./android.view.TextureView.d.ts" />
 /// <reference path="./co.fitcom.fancycamera.CameraEventListener.d.ts" />
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export abstract class CameraBase {
-				public static CameraThread: string;
-				public static CameraRecorderThread: string;
-				public static PreviewThread: string;
-				public static sessionThread: string;
-				public getHolder(): androidviewTextureView;
-				public getListener(): co.fitcom.fancycamera.CameraEventListener;
-				public setListener(param0: co.fitcom.fancycamera.CameraEventListener): void;
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export abstract class CameraBase {
+        public static CameraThread: string;
+        public static CameraRecorderThread: string;
+        public static PreviewThread: string;
+        public static sessionThread: string;
+        public getHolder(): androidviewTextureView;
+        public getListener(): co.fitcom.fancycamera.CameraEventListener;
+        public setListener(param0: co.fitcom.fancycamera.CameraEventListener): void;
+      }
+    }
+  }
 }
 
 /// <reference path="./co.fitcom.fancycamera.PhotoEvent.d.ts" />
 /// <reference path="./co.fitcom.fancycamera.VideoEvent.d.ts" />
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export class CameraEventListener {
-				/**
-				 * Constructs a new instance of the co.fitcom.fancycamera.CameraEventListener interface with the provided implementation.
-				 */
-				public constructor(implementation: {
-					onPhotoEvent(param0: co.fitcom.fancycamera.PhotoEvent): void;
-					onVideoEvent(param0: co.fitcom.fancycamera.VideoEvent): void;
-				});
-				public onPhotoEvent(param0: co.fitcom.fancycamera.PhotoEvent): void;
-				public onVideoEvent(param0: co.fitcom.fancycamera.VideoEvent): void;
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export class CameraEventListener {
+        /**
+         * Constructs a new instance of the co.fitcom.fancycamera.CameraEventListener interface with the provided implementation.
+         */
+        public constructor(implementation: {
+          onPhotoEvent(param0: co.fitcom.fancycamera.PhotoEvent): void;
+          onVideoEvent(param0: co.fitcom.fancycamera.VideoEvent): void;
+        });
+        public onPhotoEvent(param0: co.fitcom.fancycamera.PhotoEvent): void;
+        public onVideoEvent(param0: co.fitcom.fancycamera.VideoEvent): void;
+      }
+    }
+  }
 }
 
 /// <reference path="./co.fitcom.fancycamera.PhotoEvent.d.ts" />
 /// <reference path="./co.fitcom.fancycamera.VideoEvent.d.ts" />
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export abstract class CameraEventListenerUI {
-				public onPhotoEvent(param0: co.fitcom.fancycamera.PhotoEvent): void;
-				public onPhotoEventUI(param0: co.fitcom.fancycamera.PhotoEvent): void;
-				public onVideoEvent(param0: co.fitcom.fancycamera.VideoEvent): void;
-				public constructor();
-				public onVideoEventUI(param0: co.fitcom.fancycamera.VideoEvent): void;
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export abstract class CameraEventListenerUI {
+        public onPhotoEvent(param0: co.fitcom.fancycamera.PhotoEvent): void;
+        public onPhotoEventUI(param0: co.fitcom.fancycamera.PhotoEvent): void;
+        public onVideoEvent(param0: co.fitcom.fancycamera.VideoEvent): void;
+        public constructor();
+        public onVideoEventUI(param0: co.fitcom.fancycamera.VideoEvent): void;
+      }
+    }
+  }
 }
 
 /// <reference path="./java.lang.String.d.ts" />
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export class EventType {
-				public static ERROR: co.fitcom.fancycamera.EventType;
-				public static INFO: co.fitcom.fancycamera.EventType;
-				public static values(): native.Array<co.fitcom.fancycamera.EventType>;
-				public static valueOf(param0: string): co.fitcom.fancycamera.EventType;
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export class EventType {
+        public static ERROR: co.fitcom.fancycamera.EventType;
+        public static INFO: co.fitcom.fancycamera.EventType;
+        public static values(): native.Array<co.fitcom.fancycamera.EventType>;
+        public static valueOf(param0: string): co.fitcom.fancycamera.EventType;
+      }
+    }
+  }
 }
 
 import androidcontentContext = android.content.Context;
@@ -111,111 +111,111 @@ import androidgraphicsSurfaceTexture = android.graphics.SurfaceTexture;
 /// <reference path="./co.fitcom.fancycamera.CameraEventListener.d.ts" />
 /// <reference path="./java.io.File.d.ts" />
 /// <reference path="./java.lang.String.d.ts" />
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export class FancyCamera {
-				public setQuality(param0: number): void;
-				public getDuration(): number;
-				public setListener(param0: co.fitcom.fancycamera.CameraEventListener): void;
-				public startRecording(): void;
-				public requestPermission(): void;
-				public setCameraPosition(param0: number): void;
-				public onSurfaceTextureAvailable(param0: androidgraphicsSurfaceTexture, param1: number, param2: number): void;
-				public onSurfaceTextureSizeChanged(param0: androidgraphicsSurfaceTexture, param1: number, param2: number): void;
-				public hasPermission(): boolean;
-				public stop(): void;
-				public onSurfaceTextureDestroyed(param0: androidgraphicsSurfaceTexture): boolean;
-				public start(): void;
-				public setFile(param0: javaioFile): void;
-				public toggleCamera(): void;
-				public getCameraPosition(): number;
-				public constructor(param0: androidcontentContext);
-				public onSurfaceTextureUpdated(param0: androidgraphicsSurfaceTexture): void;
-				public constructor(param0: androidcontentContext, param1: androidutilAttributeSet);
-				public stopRecording(): void;
-			}
-			export module FancyCamera {
-				export class CameraPosition {
-					public static BACK: co.fitcom.fancycamera.FancyCamera.CameraPosition;
-					public static FRONT: co.fitcom.fancycamera.FancyCamera.CameraPosition;
-					public getValue(): number;
-					public static values(): native.Array<co.fitcom.fancycamera.FancyCamera.CameraPosition>;
-					public static valueOf(param0: string): co.fitcom.fancycamera.FancyCamera.CameraPosition;
-				}
-				export class Quality {
-					public static MAX_480P: co.fitcom.fancycamera.FancyCamera.Quality;
-					public static MAX_720P: co.fitcom.fancycamera.FancyCamera.Quality;
-					public static MAX_1080P: co.fitcom.fancycamera.FancyCamera.Quality;
-					public static MAX_2160P: co.fitcom.fancycamera.FancyCamera.Quality;
-					public static HIGHEST: co.fitcom.fancycamera.FancyCamera.Quality;
-					public static LOWEST: co.fitcom.fancycamera.FancyCamera.Quality;
-					public static QVGA: co.fitcom.fancycamera.FancyCamera.Quality;
-					public getValue(): number;
-					public static valueOf(param0: string): co.fitcom.fancycamera.FancyCamera.Quality;
-					public static values(): native.Array<co.fitcom.fancycamera.FancyCamera.Quality>;
-				}
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export class FancyCamera {
+        public setQuality(param0: number): void;
+        public getDuration(): number;
+        public setListener(param0: co.fitcom.fancycamera.CameraEventListener): void;
+        public startRecording(): void;
+        public requestPermission(): void;
+        public setCameraPosition(param0: number): void;
+        public onSurfaceTextureAvailable(param0: androidgraphicsSurfaceTexture, param1: number, param2: number): void;
+        public onSurfaceTextureSizeChanged(param0: androidgraphicsSurfaceTexture, param1: number, param2: number): void;
+        public hasPermission(): boolean;
+        public stop(): void;
+        public onSurfaceTextureDestroyed(param0: androidgraphicsSurfaceTexture): boolean;
+        public start(): void;
+        public setFile(param0: javaioFile): void;
+        public toggleCamera(): void;
+        public getCameraPosition(): number;
+        public constructor(param0: androidcontentContext);
+        public onSurfaceTextureUpdated(param0: androidgraphicsSurfaceTexture): void;
+        public constructor(param0: androidcontentContext, param1: androidutilAttributeSet);
+        public stopRecording(): void;
+      }
+      export namespace FancyCamera {
+        export class CameraPosition {
+          public static BACK: co.fitcom.fancycamera.FancyCamera.CameraPosition;
+          public static FRONT: co.fitcom.fancycamera.FancyCamera.CameraPosition;
+          public getValue(): number;
+          public static values(): native.Array<co.fitcom.fancycamera.FancyCamera.CameraPosition>;
+          public static valueOf(param0: string): co.fitcom.fancycamera.FancyCamera.CameraPosition;
+        }
+        export class Quality {
+          public static MAX_480P: co.fitcom.fancycamera.FancyCamera.Quality;
+          public static MAX_720P: co.fitcom.fancycamera.FancyCamera.Quality;
+          public static MAX_1080P: co.fitcom.fancycamera.FancyCamera.Quality;
+          public static MAX_2160P: co.fitcom.fancycamera.FancyCamera.Quality;
+          public static HIGHEST: co.fitcom.fancycamera.FancyCamera.Quality;
+          public static LOWEST: co.fitcom.fancycamera.FancyCamera.Quality;
+          public static QVGA: co.fitcom.fancycamera.FancyCamera.Quality;
+          public getValue(): number;
+          public static valueOf(param0: string): co.fitcom.fancycamera.FancyCamera.Quality;
+          public static values(): native.Array<co.fitcom.fancycamera.FancyCamera.Quality>;
+        }
+      }
+    }
+  }
 }
 
 /// <reference path="./co.fitcom.fancycamera.EventType.d.ts" />
 /// <reference path="./java.io.File.d.ts" />
 /// <reference path="./java.lang.String.d.ts" />
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export class PhotoEvent {
-				public getFile(): javaioFile;
-				public getMessage(): string;
-				public getType(): co.fitcom.fancycamera.EventType;
-			}
-			export module PhotoEvent {
-				export class EventError {
-					public static values(): native.Array<co.fitcom.fancycamera.PhotoEvent.EventError>;
-					public static valueOf(param0: string): co.fitcom.fancycamera.PhotoEvent.EventError;
-				}
-				export class EventInfo {
-					public static values(): native.Array<co.fitcom.fancycamera.PhotoEvent.EventInfo>;
-					public static valueOf(param0: string): co.fitcom.fancycamera.PhotoEvent.EventInfo;
-				}
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export class PhotoEvent {
+        public getFile(): javaioFile;
+        public getMessage(): string;
+        public getType(): co.fitcom.fancycamera.EventType;
+      }
+      export namespace PhotoEvent {
+        export class EventError {
+          public static values(): native.Array<co.fitcom.fancycamera.PhotoEvent.EventError>;
+          public static valueOf(param0: string): co.fitcom.fancycamera.PhotoEvent.EventError;
+        }
+        export class EventInfo {
+          public static values(): native.Array<co.fitcom.fancycamera.PhotoEvent.EventInfo>;
+          public static valueOf(param0: string): co.fitcom.fancycamera.PhotoEvent.EventInfo;
+        }
+      }
+    }
+  }
 }
 
 /// <reference path="./co.fitcom.fancycamera.EventType.d.ts" />
 /// <reference path="./java.io.File.d.ts" />
 /// <reference path="./java.lang.String.d.ts" />
-declare module co {
-	export module fitcom {
-		export module fancycamera {
-			export class VideoEvent {
-				public getFile(): javaioFile;
-				public getMessage(): string;
-				public getType(): co.fitcom.fancycamera.EventType;
-			}
-			export module VideoEvent {
-				export class EventError {
-					public static SERVER_DIED: co.fitcom.fancycamera.VideoEvent.EventError;
-					public static UNKNOWN: co.fitcom.fancycamera.VideoEvent.EventError;
-					public static values(): native.Array<co.fitcom.fancycamera.VideoEvent.EventError>;
-					public static valueOf(param0: string): co.fitcom.fancycamera.VideoEvent.EventError;
-				}
-				export class EventInfo {
-					public static RECORDING_STARTED: co.fitcom.fancycamera.VideoEvent.EventInfo;
-					public static RECORDING_FINISHED: co.fitcom.fancycamera.VideoEvent.EventInfo;
-					public static MAX_DURATION_REACHED: co.fitcom.fancycamera.VideoEvent.EventInfo;
-					public static MAX_FILESIZE_APPROACHING: co.fitcom.fancycamera.VideoEvent.EventInfo;
-					public static MAX_FILESIZE_REACHED: co.fitcom.fancycamera.VideoEvent.EventInfo;
-					public static NEXT_OUTPUT_FILE_STARTED: co.fitcom.fancycamera.VideoEvent.EventInfo;
-					public static UNKNOWN: co.fitcom.fancycamera.VideoEvent.EventInfo;
-					public static valueOf(param0: string): co.fitcom.fancycamera.VideoEvent.EventInfo;
-					public static values(): native.Array<co.fitcom.fancycamera.VideoEvent.EventInfo>;
-				}
-			}
-		}
-	}
+declare namespace co {
+  export namespace fitcom {
+    export namespace fancycamera {
+      export class VideoEvent {
+        public getFile(): javaioFile;
+        public getMessage(): string;
+        public getType(): co.fitcom.fancycamera.EventType;
+      }
+      export namespace VideoEvent {
+        export class EventError {
+          public static SERVER_DIED: co.fitcom.fancycamera.VideoEvent.EventError;
+          public static UNKNOWN: co.fitcom.fancycamera.VideoEvent.EventError;
+          public static values(): native.Array<co.fitcom.fancycamera.VideoEvent.EventError>;
+          public static valueOf(param0: string): co.fitcom.fancycamera.VideoEvent.EventError;
+        }
+        export class EventInfo {
+          public static RECORDING_STARTED: co.fitcom.fancycamera.VideoEvent.EventInfo;
+          public static RECORDING_FINISHED: co.fitcom.fancycamera.VideoEvent.EventInfo;
+          public static MAX_DURATION_REACHED: co.fitcom.fancycamera.VideoEvent.EventInfo;
+          public static MAX_FILESIZE_APPROACHING: co.fitcom.fancycamera.VideoEvent.EventInfo;
+          public static MAX_FILESIZE_REACHED: co.fitcom.fancycamera.VideoEvent.EventInfo;
+          public static NEXT_OUTPUT_FILE_STARTED: co.fitcom.fancycamera.VideoEvent.EventInfo;
+          public static UNKNOWN: co.fitcom.fancycamera.VideoEvent.EventInfo;
+          public static valueOf(param0: string): co.fitcom.fancycamera.VideoEvent.EventInfo;
+          public static values(): native.Array<co.fitcom.fancycamera.VideoEvent.EventInfo>;
+        }
+      }
+    }
+  }
 }
 

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -45,9 +45,11 @@ export class VideoRecorder {
         const sdkVersionInt = parseInt(platform.device.sdkVersion, 10);
 
         if (!options.saveToGallery) {
-          path = fs.path.join(fs.knownFolders.temp().path, fileName);
-          file = new java.io.File(path);
+          // path = fs.path.join(fs.knownFolders.temp().path, fileName);
+          // file = new java.io.File(path);
           if (sdkVersionInt >= 21) {
+            path = app.android.currentContext.getExternalCacheDir(null)
+            file = new java.io.File(path, fileName);
             tempPictureUri = (<any>android.support.v4
               .content).FileProvider.getUriForFile(
               app.android.foregroundActivity,
@@ -55,6 +57,8 @@ export class VideoRecorder {
               file
             );
           } else {
+            path = fs.path.join(fs.knownFolders.temp().path, fileName);
+            file = new java.io.File(path);
             tempPictureUri = android.net.Uri.fromFile(file);
           }
 
@@ -78,7 +82,7 @@ export class VideoRecorder {
           app.android.off(app.AndroidApplication.activityResultEvent);
           app.android.currentContext.onActivityResult = (requestCode, resultCode, resultData) => {
             if (requestCode === REQUEST_VIDEO_CAPTURE && resultCode === RESULT_OK) {
-              const mediaFile = resultData.getData();
+              const mediaFile = resultData ? resultData.getData() : file
               if (options.saveToGallery) {
                 resolve({ file: getRealPathFromURI(mediaFile) });
               } else {

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -7,20 +7,29 @@ import './async-await';
 
 import { VideoRecorder as BaseVideoRecorder } from './videorecorder.common'
 import { Options } from '.';
+import { CameraPosition } from '.';
 
 const RESULT_CANCELED = 0;
 const RESULT_OK = -1;
 const REQUEST_VIDEO_CAPTURE = 999;
 
 export class VideoRecorder extends BaseVideoRecorder{
-  public requestPermissions(options: Options = this.options): Promise<void> {
+  public requestPermissions(): Promise<void> {
     return permissions.requestPermissions(
       [
         (android as any).Manifest.permission.CAMERA,
         (android as any).Manifest.permission.RECORD_AUDIO
       ],
-      options.explanation && options.explanation.length && options.explanation
+      this.options.explanation && this.options.explanation.length && this.options.explanation
     )
+  }
+
+  public isAvailable() {
+    const feature = this.options.position === CameraPosition.FRONT
+      ? android.content.pm.PackageManager.FEATURE_CAMERA_FRONT
+      : android.content.pm.PackageManager.FEATURE_CAMERA
+
+    return app.android.currentContext.getPackageManager().hasSystemFeature(feature);
   }
 
   protected _startRecording(options: Options = this.options): Promise<any> {

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -1,30 +1,19 @@
-import { Options } from '.'
-
 import * as permissions from 'nativescript-permissions';
 import * as app from 'tns-core-modules/application';
 import * as platform from 'tns-core-modules/platform';
 import * as fs from 'tns-core-modules/file-system';
 import * as utils from 'tns-core-modules/utils/utils';
 import './async-await';
+
+import { VideoRecorder as BaseVideoRecorder } from './videorecorder.common'
+import { Options } from '.';
+
 const RESULT_CANCELED = 0;
 const RESULT_OK = -1;
 const REQUEST_VIDEO_CAPTURE = 999;
 
-export class VideoRecorder {
-  record(options?: Options): Promise<any> {
-    options = {
-      size: 0,
-      hd: false,
-      saveToGallery: false,
-      duration: 0,
-      explanation: null,
-      ...options,
-    }
-
-    return this._handlePermissions(options).then(() => this._startRecording(options))
-  }
-
-  private _handlePermissions (options: Options): Promise<any> {
+export class VideoRecorder extends BaseVideoRecorder{
+  public requestPermissions(options: Options = this.options): Promise<void> {
     return permissions.requestPermissions(
       [
         (android as any).Manifest.permission.CAMERA,
@@ -32,12 +21,9 @@ export class VideoRecorder {
       ],
       options.explanation && options.explanation.length && options.explanation
     )
-      .catch((err) => {
-        throw { event: 'denied' }
-      })
   }
 
-  private _startRecording (options: Options): Promise<any> {
+  protected _startRecording(options: Options = this.options): Promise<any> {
     return new Promise ((resolve, reject) => {
       let data = null;
       let file;

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -1,3 +1,5 @@
+import { Options } from '.'
+
 import * as permissions from 'nativescript-permissions';
 import * as app from 'tns-core-modules/application';
 import * as platform from 'tns-core-modules/platform';
@@ -15,184 +17,120 @@ const MARSHMALLOW = 23;
 const currentapiVersion = android.os.Build.VERSION.SDK_INT;
 
 export class VideoRecorder {
-  record(options: any = {}): Promise<any> {
-    return new Promise((resolve, reject) => {
-      options = options || {};
+  record(options: Options = null): Promise<any> {
+    options = options || {};
+    options.size = options.size || 0;
+    options.hd = !!options.hd;
+    options.saveToGallery = options.saveToGallery || false;
+    options.duration = options.duration || 0;
+    options.explanation = options.explanation || '';
+
+    return this._handlePermissions(options).then(() => this._startRecording(options))
+  }
+
+  private _handlePermissions (options: Options): Promise<any> {
+    return permissions.requestPermissions(
+      [
+        (android as any).Manifest.permission.CAMERA,
+        (android as any).Manifest.permission.RECORD_AUDIO
+      ],
+      options.explanation && options.explanation.length && options.explanation
+    )
+      .catch((err) => {
+        throw { event: 'denied' }
+      })
+  }
+
+  private _startRecording (options: Options): Promise<any> {
+    return new Promise ((resolve, reject) => {
       let data = null;
       let file;
       const pkgName = utils.ad.getApplication().getPackageName();
-      options.size = options.size || 0;
-      options.hd = options.hd ? 1 : 0;
-      options.saveToGallery = options.saveToGallery || false;
-      options.duration = options.duration || 0;
-      options.explanation = options.explanation || '';
-      const startRecording = () => {
-        const intent = new android.content.Intent(
-          android.provider.MediaStore.ACTION_VIDEO_CAPTURE
+
+      const state = app.android.currentContext.getExternalStorageState()
+      if (state !== android.os.Environment.MEDIA_MOUNTED) {
+        return reject({ event: 'no_external_storage_access' })
+      }
+
+      const intent = new android.content.Intent(
+        android.provider.MediaStore.ACTION_VIDEO_CAPTURE
+      );
+
+      intent.putExtra('android.intent.extra.videoQuality', options.hd ? 1 : 0);
+
+      if (options.size > 0) {
+        intent.putExtra(
+          android.provider.MediaStore.EXTRA_SIZE_LIMIT,
+          options.size * 1024 * 1024
         );
+      }
+      const fileName = `VID_${+new Date()}.mp4`;
+      let path;
+      let tempPictureUri;
+      const sdkVersionInt = parseInt(platform.device.sdkVersion, 10);
 
-        intent.putExtra('android.intent.extra.videoQuality', options.hd);
-
-        if (options.size > 0) {
-          intent.putExtra(
-            android.provider.MediaStore.EXTRA_SIZE_LIMIT,
-            options.size * 1024 * 1024
-          );
-        }
-        const fileName = `VID_${+new Date()}.mp4`;
-        let path;
-        let tempPictureUri;
-        const sdkVersionInt = parseInt(platform.device.sdkVersion, 10);
-
-        if (!options.saveToGallery) {
-          // path = fs.path.join(fs.knownFolders.temp().path, fileName);
-          // file = new java.io.File(path);
-          if (sdkVersionInt >= 21) {
-            path = app.android.currentContext.getExternalCacheDir(null)
-            file = new java.io.File(path, fileName);
-            tempPictureUri = (<any>android.support.v4
-              .content).FileProvider.getUriForFile(
-              app.android.foregroundActivity,
-              pkgName + '.provider',
-              file
-            );
-          } else {
-            path = fs.path.join(fs.knownFolders.temp().path, fileName);
-            file = new java.io.File(path);
-            tempPictureUri = android.net.Uri.fromFile(file);
-          }
-
-          intent.putExtra(
-            android.provider.MediaStore.EXTRA_OUTPUT,
-            tempPictureUri
-          );
-        }
-
-        if (options.duration > 0) {
-          intent.putExtra(
-            android.provider.MediaStore.EXTRA_DURATION_LIMIT,
-            options.duration
-          );
-        }
-
-        if (
-          intent.resolveActivity(app.android.context.getPackageManager()) !=
-          null
-        ) {
-          app.android.off(app.AndroidApplication.activityResultEvent);
-          app.android.currentContext.onActivityResult = (requestCode, resultCode, resultData) => {
-            if (requestCode === REQUEST_VIDEO_CAPTURE && resultCode === RESULT_OK) {
-              const mediaFile = resultData ? resultData.getData() : file
-              if (options.saveToGallery) {
-                resolve({ file: getRealPathFromURI(mediaFile) });
-              } else {
-                resolve({ file: file.toString() });
-              }
-            } else if (resultCode === RESULT_CANCELED) {
-              reject({ event: 'cancelled' });
-            } else {
-              reject({ event: 'failed' });
-            }
-          };
-
-          app.android.foregroundActivity.startActivityForResult(
-            intent,
-            REQUEST_VIDEO_CAPTURE
-          );
-        } else {
-          reject({ event: 'failed' });
-        }
-      };
-
-      if (currentapiVersion >= MARSHMALLOW) {
-        if (options.explanation.length > 0) {
-          if (
-            permissions.hasPermission(
-              (android as any).Manifest.permission.CAMERA
-            ) &&
-            permissions.hasPermission(
-              (android as any).Manifest.permission.RECORD_AUDIO
-            )
-          ) {
-            startRecording();
-          } else {
-            requestPermissions(options.explanation)
-              .then(function() {
-                startRecording();
-              })
-              .catch(function() {
-                reject({ event: 'camera permission needed' });
-              });
-          }
-        } else {
-          if (
-            permissions.hasPermission(
-              (android as any).Manifest.permission.CAMERA
-            ) &&
-            permissions.hasPermission(
-              (android as any).Manifest.permission.RECORD_AUDIO
-            )
-          ) {
-            startRecording();
-          } else {
-            requestPermissions(requestPermissions)
-              .then(function() {
-                startRecording();
-              })
-              .catch(function() {
-                reject({ event: 'camera permission needed' });
-              });
-          }
-        }
+      if (options.saveToGallery) {
+        path = android.os.Environment.getExternalStoragePublicDirectory(
+          android.os.Environment.DIRECTORY_DCIM
+        ).getAbsolutePath() + '/Camera';
       } else {
-        startRecording();
+        path = app.android.currentContext.getExternalFileDir(null).getAbsolutePath();
+      }
+
+      file = new java.io.File(path + '/' + fileName);
+
+      if (sdkVersionInt >= 21) {
+        tempPictureUri = (<any>android.support.v4.content).FileProvider.getUriForFile(
+          app.android.foregroundActivity, // or app.android.currentContext ??
+          `${pkgName}.provider`,
+          file
+        );
+      } else {
+        tempPictureUri = android.net.Uri.fromFile(file);
+      }
+
+      intent.putExtra(
+        android.provider.MediaStore.EXTRA_OUTPUT,
+        tempPictureUri
+      );
+
+      if (options.duration > 0) {
+        intent.putExtra(
+          android.provider.MediaStore.EXTRA_DURATION_LIMIT,
+          options.duration
+        );
+      }
+
+      if (
+        intent.resolveActivity(app.android.context.getPackageManager()) !=
+        null
+      ) {
+        app.android.off(app.AndroidApplication.activityResultEvent);
+        app.android.currentContext.onActivityResult = (requestCode, resultCode, resultData) => {
+          if (requestCode === REQUEST_VIDEO_CAPTURE && resultCode === RESULT_OK) {
+            const mediaFile = resultData ? resultData.getData() : file
+            if (options.saveToGallery) {
+              resolve({ file: getRealPathFromURI(mediaFile) });
+            } else {
+              resolve({ file: file.toString() });
+            }
+          } else if (resultCode === RESULT_CANCELED) {
+            reject({ event: 'cancelled' });
+          } else {
+            reject({ event: 'failed' });
+          }
+        };
+
+        app.android.foregroundActivity.startActivityForResult(
+          intent,
+          REQUEST_VIDEO_CAPTURE
+        );
+      } else {
+        reject({ event: 'failed' });
       }
     });
   }
 }
-
-export const requestPermissions = (options): Promise<any> => {
-  return new Promise((resolve, reject) => {
-    if (currentapiVersion >= MARSHMALLOW) {
-      if (
-        Boolean(
-          options && options.explanation && options.explanation.length > 0
-        )
-      ) {
-        permissions
-          .requestPermissions(
-            [
-              (android as any).Manifest.permission.CAMERA,
-              (android as any).Manifest.permission.RECORD_AUDIO
-            ],
-            options.explanation
-          )
-          .then(granted => {
-            console.dir(granted);
-            resolve();
-          })
-          .catch(() => {
-            reject();
-          });
-      } else {
-        permissions
-          .requestPermissions([
-            (android as any).Manifest.permission.CAMERA,
-            (android as any).Manifest.permission.RECORD_AUDIO
-          ])
-          .then(granted => {
-            console.log(granted);
-            resolve();
-          })
-          .catch(() => {
-            reject();
-          });
-      }
-    } else {
-      resolve();
-    }
-  });
-};
 
 function getRealPathFromURI(contentUri: android.net.Uri): string {
   let path: string;

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -5,15 +5,18 @@ import * as fs from 'tns-core-modules/file-system';
 import * as utils from 'tns-core-modules/utils/utils';
 import './async-await';
 
-import { VideoRecorder as BaseVideoRecorder } from './videorecorder.common'
-import { Options, RecordResult } from '.';
-import { CameraPosition } from '.';
+import {
+  VideoRecorderCommon,
+  Options, RecordResult, CameraPosition,
+} from './videorecorder.common';
+
+export * from './videorecorder.common';
 
 const RESULT_CANCELED = 0;
 const RESULT_OK = -1;
 const REQUEST_VIDEO_CAPTURE = 999;
 
-export class VideoRecorder extends BaseVideoRecorder{
+export class VideoRecorder extends VideoRecorderCommon {
   public requestPermissions(): Promise<void> {
     return permissions.requestPermissions(
       [
@@ -21,13 +24,13 @@ export class VideoRecorder extends BaseVideoRecorder{
         (android as any).Manifest.permission.RECORD_AUDIO
       ],
       this.options.explanation && this.options.explanation.length && this.options.explanation
-    )
+    );
   }
 
   public isAvailable() {
     const feature = this.options.position === CameraPosition.FRONT
       ? android.content.pm.PackageManager.FEATURE_CAMERA_FRONT
-      : android.content.pm.PackageManager.FEATURE_CAMERA
+      : android.content.pm.PackageManager.FEATURE_CAMERA;
 
     return app.android.currentContext.getPackageManager().hasSystemFeature(feature);
   }
@@ -38,9 +41,9 @@ export class VideoRecorder extends BaseVideoRecorder{
       let file;
       const pkgName = utils.ad.getApplication().getPackageName();
 
-      const state = app.android.currentContext.getExternalStorageState()
+      const state = android.os.Environment.getExternalStorageState();
       if (state !== android.os.Environment.MEDIA_MOUNTED) {
-        return reject({ event: 'failed' })
+        return reject({ event: 'failed' });
       }
 
       const intent = new android.content.Intent(
@@ -76,7 +79,7 @@ export class VideoRecorder extends BaseVideoRecorder{
           android.os.Environment.DIRECTORY_DCIM
         ).getAbsolutePath() + '/Camera';
       } else {
-        path = app.android.currentContext.getExternalFileDir(null).getAbsolutePath();
+        path = app.android.currentContext.getExternalFilesDir(null).getAbsolutePath();
       }
 
       file = new java.io.File(path + '/' + fileName);
@@ -110,7 +113,7 @@ export class VideoRecorder extends BaseVideoRecorder{
         app.android.off(app.AndroidApplication.activityResultEvent);
         app.android.currentContext.onActivityResult = (requestCode, resultCode, resultData) => {
           if (requestCode === REQUEST_VIDEO_CAPTURE && resultCode === RESULT_OK) {
-            const mediaFile = resultData ? resultData.getData() : file
+            const mediaFile = resultData ? resultData.getData() : file;
             if (options.saveToGallery) {
               resolve({ file: getRealPathFromURI(mediaFile) });
             } else {

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -6,7 +6,7 @@ import * as utils from 'tns-core-modules/utils/utils';
 import './async-await';
 
 import { VideoRecorder as BaseVideoRecorder } from './videorecorder.common'
-import { Options } from '.';
+import { Options, RecordResult } from '.';
 import { CameraPosition } from '.';
 
 const RESULT_CANCELED = 0;
@@ -32,7 +32,7 @@ export class VideoRecorder extends BaseVideoRecorder{
     return app.android.currentContext.getPackageManager().hasSystemFeature(feature);
   }
 
-  protected _startRecording(options: Options = this.options): Promise<any> {
+  protected _startRecording(options: Options = this.options): Promise<RecordResult> {
     return new Promise ((resolve, reject) => {
       let data = null;
       let file;
@@ -65,7 +65,7 @@ export class VideoRecorder extends BaseVideoRecorder{
           options.size * 1024 * 1024
         );
       }
-      
+
       const fileName = `VID_${+new Date()}.mp4`;
       let path;
       let tempPictureUri;

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -9,21 +9,17 @@ import './async-await';
 const RESULT_CANCELED = 0;
 const RESULT_OK = -1;
 const REQUEST_VIDEO_CAPTURE = 999;
-const REQUEST_CODE_ASK_PERMISSIONS = 1000;
-const ORIENTATION_UNKNOWN = -1;
-const PERMISSION_DENIED = -1;
-const PERMISSION_GRANTED = 0;
-const MARSHMALLOW = 23;
-const currentapiVersion = android.os.Build.VERSION.SDK_INT;
 
 export class VideoRecorder {
-  record(options: Options = null): Promise<any> {
-    options = options || {};
-    options.size = options.size || 0;
-    options.hd = !!options.hd;
-    options.saveToGallery = options.saveToGallery || false;
-    options.duration = options.duration || 0;
-    options.explanation = options.explanation || '';
+  record(options?: Options): Promise<any> {
+    options = {
+      size: 0,
+      hd: false,
+      saveToGallery: false,
+      duration: 0,
+      explanation: null,
+      ...options,
+    }
 
     return this._handlePermissions(options).then(() => this._startRecording(options))
   }
@@ -49,7 +45,7 @@ export class VideoRecorder {
 
       const state = app.android.currentContext.getExternalStorageState()
       if (state !== android.os.Environment.MEDIA_MOUNTED) {
-        return reject({ event: 'no_external_storage_access' })
+        return reject({ event: 'failed' })
       }
 
       const intent = new android.content.Intent(

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -49,12 +49,23 @@ export class VideoRecorder extends BaseVideoRecorder{
 
       intent.putExtra('android.intent.extra.videoQuality', options.hd ? 1 : 0);
 
+
+      if (options.position !== CameraPosition.NONE) {
+        intent.putExtra(
+          'android.intent.extras.CAMERA_FACING',
+          options.position === CameraPosition.BACK
+            ? android.hardware.Camera.CameraInfo.CAMERA_FACING_FRONT
+            : android.hardware.Camera.CameraInfo.CAMERA_FACING_BACK
+        );
+      }
+
       if (options.size > 0) {
         intent.putExtra(
           android.provider.MediaStore.EXTRA_SIZE_LIMIT,
           options.size * 1024 * 1024
         );
       }
+      
       const fileName = `VID_${+new Date()}.mp4`;
       let path;
       let tempPictureUri;

--- a/src/videorecorder.common.ts
+++ b/src/videorecorder.common.ts
@@ -29,7 +29,7 @@ export enum VideoFormat {
 export abstract class VideoRecorderCommon {
   options: Options;
 
-  constructor(options?: Options) {
+  constructor(options: Options = {}) {
     this.options = Object.assign(
       Object.assign({
         format: VideoFormat.DEFAULT,
@@ -45,8 +45,8 @@ export abstract class VideoRecorderCommon {
   }
 
   // @deprecated Options as argument is deprecated here
-  public record(options?: Options): Promise<RecordResult> {
-    options = Object.assign(this.options, options || {});
+  public record(options: Options = {}): Promise<RecordResult> {
+    options = Object.assign(this.options, options);
 
     return this.requestPermissions(options).catch((err) => {
       throw { event: 'denied' };

--- a/src/videorecorder.common.ts
+++ b/src/videorecorder.common.ts
@@ -1,47 +1,67 @@
-import {
-  VideoRecorder as VideoRecorderDefinition,
-  VideoFormat,
-  CameraPosition,
-  RecordResult
-} from '.'
-import { Options } from '.'
+export interface Options {
+  size?: number;
+  hd?: boolean;
+  saveToGallery?: boolean;
+  duration?: number;
+  explanation?: string;
+  format?: VideoFormatType;
+  position?: CameraPositionType;
+}
 
-export abstract class VideoRecorder implements VideoRecorderDefinition {
-  options: Options
-  
+export interface RecordResult {
+  file: string;
+}
+
+export type CameraPositionType = 'front' | 'back' | 'none';
+export type VideoFormatType = 'default' | 'mp4';
+
+export enum CameraPosition {
+  FRONT = 'front',
+  BACK = 'back',
+  NONE = 'none',
+}
+
+export enum VideoFormat {
+  DEFAULT = 'default',
+  MP4 = 'mp4',
+}
+
+export abstract class VideoRecorderCommon {
+  options: Options;
+
   constructor(options?: Options) {
-    this.options = {
-      format: VideoFormat.DEFAULT,
-      position: CameraPosition.NONE,
-      size: 0,
-      duration: 0,
-      explanation: null,
-      ...options,
-      saveToGallery: !!options.saveToGallery,
-      hd: !!options.hd,
-    }
+    this.options = Object.assign(
+      Object.assign({
+        format: VideoFormat.DEFAULT,
+        position: CameraPosition.NONE,
+        size: 0,
+        duration: 0,
+        explanation: null
+      }, options || {}), {
+        saveToGallery: !!options.saveToGallery,
+        hd: !!options.hd,
+      }
+    );
   }
 
   // @deprecated Options as argument is deprecated here
   public record(options?: Options): Promise<RecordResult> {
-    options = { ...this.options, ...options }
+    options = Object.assign(this.options, options || {});
 
     return this.requestPermissions(options).catch((err) => {
-      throw { event: 'denied' }
-    }).then(() => this._startRecording(options))
+      throw { event: 'denied' };
+    }).then(() => { return this._startRecording(options); });
   }
 
   public requestPermissions(options?: Options): Promise<any> {
-    return Promise.resolve()
+    return Promise.resolve();
   }
 
   public isAvailable(): boolean {
-    return false
+    return false;
   }
 
   protected _startRecording(options?: Options): Promise<RecordResult> {
-    return Promise.reject({ event: 'failed' })
+    return Promise.reject({ event: 'failed' });
   }
 }
-
-export default VideoRecorder

--- a/src/videorecorder.common.ts
+++ b/src/videorecorder.common.ts
@@ -1,0 +1,37 @@
+import { VideoRecorder as VideoRecorderDefinition } from '.'
+import { Options } from '.'
+
+export abstract class VideoRecorder implements VideoRecorderDefinition {
+  options: Options
+  
+  constructor(options?: Options) {
+    this.options = {
+      format: 'default',
+      position: 'back',
+      size: 0,
+      duration: 0,
+      explanation: null,
+      ...options,
+      saveToGallery: !!options.saveToGallery,
+      hd: !!options.hd,
+    }
+  }
+
+  public record(options?: Options): Promise<any> {
+    options = { ...this.options, ...options }
+
+    return this.requestPermissions(options).catch((err) => {
+      throw { event: 'denied' }
+    }).then(() => this._startRecording(options))
+  }
+
+  public requestPermissions(options?: Options): Promise<any> {
+    return Promise.resolve()
+  }
+
+  protected _startRecording(options?: Options): Promise<any> {
+    return Promise.reject({ event: 'failed' })
+  }
+}
+
+export default VideoRecorder

--- a/src/videorecorder.common.ts
+++ b/src/videorecorder.common.ts
@@ -1,4 +1,9 @@
-import { VideoRecorder as VideoRecorderDefinition, VideoFormat, CameraPosition } from '.'
+import {
+  VideoRecorder as VideoRecorderDefinition,
+  VideoFormat,
+  CameraPosition,
+  RecordResult
+} from '.'
 import { Options } from '.'
 
 export abstract class VideoRecorder implements VideoRecorderDefinition {
@@ -18,7 +23,7 @@ export abstract class VideoRecorder implements VideoRecorderDefinition {
   }
 
   // @deprecated Options as argument is deprecated here
-  public record(options?: Options): Promise<any> {
+  public record(options?: Options): Promise<RecordResult> {
     options = { ...this.options, ...options }
 
     return this.requestPermissions(options).catch((err) => {
@@ -34,7 +39,7 @@ export abstract class VideoRecorder implements VideoRecorderDefinition {
     return false
   }
 
-  protected _startRecording(options?: Options): Promise<any> {
+  protected _startRecording(options?: Options): Promise<RecordResult> {
     return Promise.reject({ event: 'failed' })
   }
 }

--- a/src/videorecorder.common.ts
+++ b/src/videorecorder.common.ts
@@ -1,4 +1,4 @@
-import { VideoRecorder as VideoRecorderDefinition } from '.'
+import { VideoRecorder as VideoRecorderDefinition, VideoFormat, CameraPosition } from '.'
 import { Options } from '.'
 
 export abstract class VideoRecorder implements VideoRecorderDefinition {
@@ -6,8 +6,8 @@ export abstract class VideoRecorder implements VideoRecorderDefinition {
   
   constructor(options?: Options) {
     this.options = {
-      format: 'default',
-      position: 'back',
+      format: VideoFormat.DEFAULT,
+      position: CameraPosition.NONE,
       size: 0,
       duration: 0,
       explanation: null,

--- a/src/videorecorder.common.ts
+++ b/src/videorecorder.common.ts
@@ -17,6 +17,7 @@ export abstract class VideoRecorder implements VideoRecorderDefinition {
     }
   }
 
+  // @deprecated Options as argument is deprecated here
   public record(options?: Options): Promise<any> {
     options = { ...this.options, ...options }
 
@@ -27,6 +28,10 @@ export abstract class VideoRecorder implements VideoRecorderDefinition {
 
   public requestPermissions(options?: Options): Promise<any> {
     return Promise.resolve()
+  }
+
+  public isAvailable(): boolean {
+    return false
   }
 
   protected _startRecording(options?: Options): Promise<any> {

--- a/src/videorecorder.ios.ts
+++ b/src/videorecorder.ios.ts
@@ -5,15 +5,19 @@ import { Color } from 'tns-core-modules/color';
 import { View, layout, Property } from 'tns-core-modules/ui/core/view';
 import './async-await';
 
-import { Options, VideoFormat, VideoFormatType, CameraPosition, RecordResult } from '.'
-import { VideoRecorder as BaseVideoRecorder } from './videorecorder.common'
+import {
+  VideoRecorderCommon,
+  Options, VideoFormat, VideoFormatType, CameraPosition, RecordResult,
+} from './videorecorder.common';
+
+export * from './videorecorder.common';
 
 let listener;
-export class VideoRecorder extends BaseVideoRecorder {
+export class VideoRecorder extends VideoRecorderCommon {
   public requestPermissions (): Promise<any> {
     return new Promise((resolve, reject) => {
       // Permission is only necessary when file needs to be saved in gallery
-      if (!this.options.saveToGallery) return resolve()
+      if (!this.options.saveToGallery) return resolve();
 
       let authStatus = PHPhotoLibrary.authorizationStatus();
       if (authStatus === PHAuthorizationStatus.NotDetermined) {

--- a/src/videorecorder.ios.ts
+++ b/src/videorecorder.ios.ts
@@ -5,15 +5,15 @@ import { Color } from 'tns-core-modules/color';
 import { View, layout, Property } from 'tns-core-modules/ui/core/view';
 import './async-await';
 
-import { Options, VideoFormat } from '.'
+import { Options, VideoFormat, VideoFormatType } from '.'
 import { VideoRecorder as BaseVideoRecorder } from './videorecorder.common'
 
 let listener;
 export class VideoRecorder extends BaseVideoRecorder {
-  public requestPermissions (options: Options = this.options): Promise<any> {
+  public requestPermissions (): Promise<any> {
     return new Promise((resolve, reject) => {
       // Permission is only necessary when file needs to be saved in gallery
-      if (!options.saveToGallery) return resolve()
+      if (!this.options.saveToGallery) return resolve()
 
       let authStatus = PHPhotoLibrary.authorizationStatus();
       if (authStatus === PHAuthorizationStatus.NotDetermined) {
@@ -26,7 +26,11 @@ export class VideoRecorder extends BaseVideoRecorder {
         reject();
       }
     });
-  };
+  }
+
+  public isAvailable() {
+    return UIImagePickerController.isSourceTypeAvailable(UIImagePickerControllerSourceType.Camera);
+  }
 
   protected _startRecording(options: Options = this.options): Promise<any> {
     return new Promise((resolve, reject) => {
@@ -82,7 +86,7 @@ class UIImagePickerControllerDelegateImpl extends NSObject
   public static ObjCProtocols = [UIImagePickerControllerDelegate];
   private _saveToGallery: boolean;
   private _callback: (result?) => void;
-  private _format: VideoFormat = 'default';
+  private _format: VideoFormatType = VideoFormat.DEFAULT;
   private _hd: boolean;
   public static initWithCallback(
     callback: (result?) => void
@@ -121,7 +125,7 @@ class UIImagePickerControllerDelegateImpl extends NSObject
       let currentDate: Date = new Date();
       if (this._saveToGallery) {
         let source = info.objectForKey(UIImagePickerControllerMediaURL);
-        if (this._format === 'mp4') {
+        if (this._format === VideoFormat.MP4) {
           let asset = AVAsset.assetWithURL(source);
           let preset = this._hd
             ? AVAssetExportPresetHighestQuality
@@ -162,7 +166,7 @@ class UIImagePickerControllerDelegateImpl extends NSObject
         }
       } else {
         let source = info.objectForKey(UIImagePickerControllerMediaURL);
-        if (this._format === 'mp4') {
+        if (this._format === VideoFormat.MP4) {
           let asset = AVAsset.assetWithURL(source);
           let preset = this._hd
             ? AVAssetExportPresetHighestQuality

--- a/src/videorecorder.ios.ts
+++ b/src/videorecorder.ios.ts
@@ -1,3 +1,5 @@
+import { Options, VideoFormat, CameraPosition } from '.'
+
 import * as frame from 'tns-core-modules/ui/frame';
 import * as fs from 'tns-core-modules/file-system';
 import * as types from 'tns-core-modules/utils/types';
@@ -7,7 +9,7 @@ import './async-await';
 let listener;
 export class VideoRecorder {
   public record(
-    options = {
+    options: Options = {
       saveToGallery: false,
       hd: false,
       format: 'default',
@@ -73,7 +75,6 @@ export class VideoRecorder {
     });
   }
 }
-export type VideoFormat = 'default' | 'mp4';
 class UIImagePickerControllerDelegateImpl extends NSObject
   implements UIImagePickerControllerDelegate {
   public static ObjCProtocols = [UIImagePickerControllerDelegate];
@@ -189,7 +190,6 @@ class UIImagePickerControllerDelegateImpl extends NSObject
     }
   }
 }
-export type CameraPosition = 'front' | 'back';
 export const requestPermissions = function(): Promise<any> {
   return new Promise((resolve, reject) => {
     let authStatus = PHPhotoLibrary.authorizationStatus();

--- a/src/videorecorder.ios.ts
+++ b/src/videorecorder.ios.ts
@@ -5,7 +5,7 @@ import { Color } from 'tns-core-modules/color';
 import { View, layout, Property } from 'tns-core-modules/ui/core/view';
 import './async-await';
 
-import { Options, VideoFormat, VideoFormatType } from '.'
+import { Options, VideoFormat, VideoFormatType, CameraPosition } from '.'
 import { VideoRecorder as BaseVideoRecorder } from './videorecorder.common'
 
 let listener;
@@ -36,10 +36,15 @@ export class VideoRecorder extends BaseVideoRecorder {
     return new Promise((resolve, reject) => {
       listener = null;
       let picker = UIImagePickerController.new();
-      let sourceType = UIImagePickerControllerSourceType.Camera;
       picker.mediaTypes = <any>[kUTTypeMovie];
-      picker.sourceType = sourceType;
+      picker.sourceType = UIImagePickerControllerSourceType.Camera;
       picker.cameraCaptureMode = UIImagePickerControllerCameraCaptureMode.Video;
+
+      if (options.position !== CameraPosition.NONE) {
+        picker.cameraDevice = options.position === CameraPosition.FRONT
+          ? UIImagePickerControllerCameraDevice.Front
+          : UIImagePickerControllerCameraDevice.Rear;
+      }
 
       picker.allowsEditing = false;
       picker.videoQuality = options.hd

--- a/src/videorecorder.ios.ts
+++ b/src/videorecorder.ios.ts
@@ -5,7 +5,7 @@ import { Color } from 'tns-core-modules/color';
 import { View, layout, Property } from 'tns-core-modules/ui/core/view';
 import './async-await';
 
-import { Options, VideoFormat, VideoFormatType, CameraPosition } from '.'
+import { Options, VideoFormat, VideoFormatType, CameraPosition, RecordResult } from '.'
 import { VideoRecorder as BaseVideoRecorder } from './videorecorder.common'
 
 let listener;
@@ -32,7 +32,7 @@ export class VideoRecorder extends BaseVideoRecorder {
     return UIImagePickerController.isSourceTypeAvailable(UIImagePickerControllerSourceType.Camera);
   }
 
-  protected _startRecording(options: Options = this.options): Promise<any> {
+  protected _startRecording(options: Options = this.options): Promise<RecordResult> {
     return new Promise((resolve, reject) => {
       listener = null;
       let picker = UIImagePickerController.new();
@@ -90,7 +90,7 @@ class UIImagePickerControllerDelegateImpl extends NSObject
   implements UIImagePickerControllerDelegate {
   public static ObjCProtocols = [UIImagePickerControllerDelegate];
   private _saveToGallery: boolean;
-  private _callback: (result?) => void;
+  private _callback: (result?: RecordResult) => void;
   private _format: VideoFormatType = VideoFormat.DEFAULT;
   private _hd: boolean;
   public static initWithCallback(
@@ -102,7 +102,7 @@ class UIImagePickerControllerDelegateImpl extends NSObject
   }
   public static initWithOwnerCallbackOptions(
     owner: any /*WeakRef<VideoRecorder>*/,
-    callback: (result?) => void,
+    callback: (result?: RecordResult) => void,
     options?: Options
   ): UIImagePickerControllerDelegateImpl {
     let delegate = new UIImagePickerControllerDelegateImpl();
@@ -162,7 +162,7 @@ class UIImagePickerControllerDelegateImpl extends NSObject
             source,
             (file, error) => {
               if (!error) {
-                this._callback();
+                this._callback({ file: file.path });
               } else {
                 console.log(error.localizedDescription);
               }

--- a/src/videorecorder.ios.ts
+++ b/src/videorecorder.ios.ts
@@ -9,15 +9,18 @@ import './async-await';
 let listener;
 export class VideoRecorder {
   public record(
-    options: Options = {
+    options?: Options
+  ): Promise<any> {
+    options = {
       saveToGallery: false,
       hd: false,
       format: 'default',
       position: 'back',
       size: 0,
-      duration: 0
+      duration: 0,
+      ...options,
     }
-  ): Promise<any> {
+
     return new Promise((resolve, reject) => {
       listener = null;
       let picker = UIImagePickerController.new();


### PR DESCRIPTION
Hey !

Like promised, I did some changes for the `VideoRecorder`, working like a charm on Android all versions, and on iOS. I didn't touched the `AdvancedVideoRecorder`, but it's my next step.

Changes I made are retro-compatibles, except for one, I moved `requestPermissions` inside the class.
I improved a little bit the structure, by using a `common` file.

I also improved error reporting and fixed some issues with the promises (when requiring permissions, mainly).

I fixed:
* Issue #41 due to the use of API incorrectly
* Issue #38 
* Hopefuly #21 but I can't reproduce

I also added those features:
* choosing starting camera position on iOS & Android (front, back or none)
* an `isAvailable()` method to check if device has camera support

I improved a bit the README and did a few other minor fixes and changes, no big deal.

Please review! (I know it's a big one, but didn't had time to do small batches)

Here are changes from commits:
```
fix: optional uses-feature camera & camera autofocus
fix: android recording on Marshmallow+ (#41, #21)
chore: typings for options
refactor: refactor android file + better handling of errors and permi…
refactor: better handle of default options
refactor: use a common file to keep common logic in one place
doc: update README
feat: add VideoRecorder::isAvailable() method, and deprecate options …
feat: add options.position = 'front' | 'back' | 'none'
fix: path of camera roll is now returned on ios (#38)
```