### PR TITLE
feat: outputOrientation + use last version of FancyCamera + torch on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,14 @@ advancedView.startRecording();
 | toggleCamera()          |          | void    | Toggles between front or the back camera.             |
 | duration                |          | int     | Get the current recording video duration.             |
 | cameraPosition          | BACK     | void    | Gets or Sets camera position                          |
+| outputOrientation       | PORTRAIT | void    | Gets or Sets output video orientation                 |
 | quality                 | MAX_480P | void    | Gets or sets Video Quality                            |
+
+#### outputOrientation
+
+Be careful to not change orientation while recording, it's not supported.
+
+Possible values : `portrait`, `portraitUpsideDown`, `landscapeLeft`, `landscapeRight`, you can also use the `Orientation` enum.
+
+This property let you manage the orientation of the output file correctly, it means you can trust your gravity sensors to detect orientation and set it on the camera.
+With this, you can properly change orientation even when device orientation is locked.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,12 @@ advancedView.startRecording();
 | startRecording()        |          | void    | Start recording camera preview.                       |
 | stopRecording()         |          | void    | Stop recording camera preview.                        |
 | toggleCamera()          |          | void    | Toggles between front or the back camera.             |
+| toggleTorch()           |          | void    | Toggles the torch (iOS only for now)                  |
 | duration                |          | int     | Get the current recording video duration.             |
 | cameraPosition          | BACK     | void    | Gets or Sets camera position                          |
 | outputOrientation       | PORTRAIT | void    | Gets or Sets output video orientation                 |
+| isTorchAvailable        |          | boolean | ReadOnly: is the torch supported for this camera      |
+| torch                   | false    | boolean | Enable/Disable torch (iOS only for now)               |
 | quality                 | MAX_480P | void    | Gets or sets Video Quality                            |
 
 #### outputOrientation

--- a/src/advanced/advanced-video-view.android.d.ts
+++ b/src/advanced/advanced-video-view.android.d.ts
@@ -1,5 +1,13 @@
 import '../async-await';
 import { AdvancedVideoViewBase } from './advanced-video-view.common';
+export * from './advanced-video-view.common';
+export declare enum NativeOrientation {
+    Unknown = 0,
+    Portrait = 1,
+    PortraitUpsideDown = 2,
+    LandscapeLeft = 3,
+    LandscapeRight = 4,
+}
 export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     thumbnails: any[];
     readonly duration: any;
@@ -11,9 +19,10 @@ export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     onLoaded(): void;
     onUnloaded(): void;
     private setCameraPosition(position);
+    private setCameraOrientation(orientation);
     private setQuality(quality);
     toggleCamera(): void;
-    startRecording(cb: any): void;
+    startRecording(): void;
     stopRecording(): void;
     startPreview(): void;
     stopPreview(): void;

--- a/src/advanced/advanced-video-view.android.d.ts
+++ b/src/advanced/advanced-video-view.android.d.ts
@@ -21,6 +21,8 @@ export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     private setCameraPosition(position);
     private setCameraOrientation(orientation);
     private setQuality(quality);
+    readonly isTorchAvailable: boolean;
+    toggleTorch(): void;
     toggleCamera(): void;
     startRecording(): void;
     stopRecording(): void;

--- a/src/advanced/advanced-video-view.android.ts
+++ b/src/advanced/advanced-video-view.android.ts
@@ -12,6 +12,7 @@ import { fromObject } from 'tns-core-modules/data/observable';
 import * as app from 'tns-core-modules/application';
 import * as permissions from 'nativescript-permissions';
 let MediaMetadataRetriever = android.media.MediaMetadataRetriever;
+
 export class AdvancedVideoView extends AdvancedVideoViewBase {
     thumbnails: any[];
     get duration() {
@@ -53,6 +54,8 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
         let that = this;
         const listener = (co as any).fitcom.fancycamera.CameraEventListenerUI.extend(
             {
+                onCameraOpenUI() {},
+                onCameraCloseUI() {},
                 onVideoEventUI(event: co.fitcom.fancycamera.VideoEvent) {
                     const owner = ref.get();
                     if (
@@ -109,6 +112,7 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
         this.nativeView.setListener(new listener());
         this.setQuality(this.quality);
         this.setCameraPosition(this.cameraPosition);
+        this.nativeView.setCameraOrientation(2);
     }
 
     public onLoaded(): void {
@@ -212,7 +216,7 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
         this.nativeView.toggleCamera();
     }
 
-    public startRecording(cb): void {
+    public startRecording(): void {
         this.nativeView.startRecording();
     }
 

--- a/src/advanced/advanced-video-view.android.ts
+++ b/src/advanced/advanced-video-view.android.ts
@@ -7,7 +7,8 @@ import {
     qualityProperty,
     saveToGalleryProperty,
     Orientation,
-    outputOrientation
+    outputOrientation,
+    torchProperty
 } from './advanced-video-view.common';
 
 export * from './advanced-video-view.common';
@@ -261,6 +262,31 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
         if (!quality) return quality;
         this.setQuality(this.quality);
         return quality;
+    }
+
+
+    [torchProperty.getDefault]() {
+        return false;
+    }
+
+    [torchProperty.setNative](torch) {
+        if (!this.isTorchAvailable || !this.nativeView) return false;
+        if (torch && !this.nativeView.flashEnabled) {
+            this.nativeView.enableFlash();
+        } else if (!torch && this.nativeView.flashEnabled) {
+            this.nativeView.disableFlash();
+        }
+        return torch;
+    }
+
+    public get isTorchAvailable() {
+        return false; // this.nativeView && this.nativeView.hasFlash();
+    }
+
+    public toggleTorch() {
+        if (!this.isTorchAvailable) return;
+        console.log('toggleFlash is called', this.torch);
+        this.torch = !this.torch;
     }
 
     public toggleCamera() {

--- a/src/advanced/advanced-video-view.android.ts
+++ b/src/advanced/advanced-video-view.android.ts
@@ -5,13 +5,26 @@ import {
     cameraPositionProperty,
     Quality,
     qualityProperty,
-    saveToGalleryProperty
+    saveToGalleryProperty,
+    Orientation,
+    outputOrientation
 } from './advanced-video-view.common';
+
+export * from './advanced-video-view.common';
+
 import { fromObject } from 'tns-core-modules/data/observable';
 // declare const com;
 import * as app from 'tns-core-modules/application';
 import * as permissions from 'nativescript-permissions';
 let MediaMetadataRetriever = android.media.MediaMetadataRetriever;
+
+export enum NativeOrientation {
+    Unknown,
+    Portrait,
+    PortraitUpsideDown,
+    LandscapeLeft,
+    LandscapeRight,
+}
 
 export class AdvancedVideoView extends AdvancedVideoViewBase {
     thumbnails: any[];
@@ -112,6 +125,7 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
         this.nativeView.setListener(new listener());
         this.setQuality(this.quality);
         this.setCameraPosition(this.cameraPosition);
+        this.setCameraOrientation(this.outputOrientation);
         this.nativeView.setCameraOrientation(2);
     }
 
@@ -149,6 +163,43 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
             this.setCameraPosition(position);
         }
         return position;
+    }
+
+    private setCameraOrientation(orientation: Orientation): void {
+        let nativeOrientation: number;
+        switch (orientation) {
+            case Orientation.LandscapeLeft:
+                nativeOrientation = co.fitcom.fancycamera.FancyCamera.CameraOrientation.LANDSCAPE_LEFT.getValue();
+                break;
+            case Orientation.LandscapeRight:
+                nativeOrientation = co.fitcom.fancycamera.FancyCamera.CameraOrientation.LANDSCAPE_RIGHT.getValue();
+                break;
+            case Orientation.Portrait:
+                nativeOrientation = co.fitcom.fancycamera.FancyCamera.CameraOrientation.PORTRAIT.getValue();
+                break;
+            case Orientation.PortraitUpsideDown:
+                nativeOrientation = co.fitcom.fancycamera.FancyCamera.CameraOrientation.PORTRAIT_UPSIDE_DOWN.getValue();
+                break;
+            default:
+                nativeOrientation = co.fitcom.fancycamera.FancyCamera.CameraOrientation.UNKNOWN.getValue();
+                break;
+        }
+
+        if (this.nativeView && nativeOrientation !== NativeOrientation.Unknown) {
+            this.nativeView.setCameraOrientation(nativeOrientation);
+        }
+    }
+
+    [outputOrientation.getDefault](): Orientation {
+        this.setCameraOrientation(Orientation.Unknown);
+        return Orientation.Unknown;
+    }
+
+    [outputOrientation.setNative](orientation: Orientation) {
+        if (this.nativeView) {
+            this.setCameraOrientation(orientation);
+        }
+        return orientation;
     }
 
     [saveToGalleryProperty.getDefault]() {

--- a/src/advanced/advanced-video-view.common.d.ts
+++ b/src/advanced/advanced-video-view.common.d.ts
@@ -12,16 +12,32 @@ export declare enum Quality {
     LOWEST = "lowest",
     QVGA = "qvga",
 }
+export declare enum Orientation {
+    Unknown = "unknown",
+    Portrait = "portrait",
+    PortraitUpsideDown = "portraitUpsideDown",
+    LandscapeLeft = "landscapeLeft",
+    LandscapeRight = "landscapeRight",
+}
 export declare type CameraPositionType = 'back' | 'front';
-export declare class AdvancedVideoViewBase extends View {
+export declare abstract class AdvancedVideoViewBase extends View {
     cameraPosition: CameraPositionType;
     saveToGallery: boolean;
     quality: Quality;
     thumbnailCount: number;
     fill: boolean;
+    outputOrientation: Orientation;
+    readonly abstract duration: number;
+    readonly abstract thumbnails: string[];
+    abstract startRecording(): void;
+    abstract stopRecording(): void;
+    abstract stopPreview(): void;
+    abstract toggleCamera(): void;
+    abstract startPreview(): void;
     static isAvailable(): boolean;
     static requestPermissions(explanation?: string): Promise<any>;
 }
+export declare const outputOrientation: Property<AdvancedVideoViewBase, string>;
 export declare const fillProperty: Property<AdvancedVideoViewBase, boolean>;
 export declare const thumbnailCountProperty: Property<AdvancedVideoViewBase, number>;
 export declare const qualityProperty: Property<AdvancedVideoViewBase, any>;

--- a/src/advanced/advanced-video-view.common.d.ts
+++ b/src/advanced/advanced-video-view.common.d.ts
@@ -26,6 +26,7 @@ export declare abstract class AdvancedVideoViewBase extends View {
     quality: Quality;
     thumbnailCount: number;
     fill: boolean;
+    torch: boolean;
     outputOrientation: Orientation;
     readonly abstract duration: number;
     readonly abstract thumbnails: string[];
@@ -33,12 +34,15 @@ export declare abstract class AdvancedVideoViewBase extends View {
     abstract stopRecording(): void;
     abstract stopPreview(): void;
     abstract toggleCamera(): void;
+    abstract toggleTorch(): void;
     abstract startPreview(): void;
+    readonly abstract isTorchAvailable: boolean;
     static isAvailable(): boolean;
     static requestPermissions(explanation?: string): Promise<any>;
 }
 export declare const outputOrientation: Property<AdvancedVideoViewBase, string>;
 export declare const fillProperty: Property<AdvancedVideoViewBase, boolean>;
+export declare const torchProperty: Property<AdvancedVideoViewBase, boolean>;
 export declare const thumbnailCountProperty: Property<AdvancedVideoViewBase, number>;
 export declare const qualityProperty: Property<AdvancedVideoViewBase, any>;
 export declare const cameraPositionProperty: Property<AdvancedVideoViewBase, CameraPositionType>;

--- a/src/advanced/advanced-video-view.common.ts
+++ b/src/advanced/advanced-video-view.common.ts
@@ -15,14 +15,32 @@ export enum Quality {
     QVGA = 'qvga'
 }
 
+export enum Orientation {
+    Unknown = 'unknown',
+    Portrait = 'portrait',
+    PortraitUpsideDown = 'portraitUpsideDown',
+    LandscapeLeft = 'landscapeLeft',
+    LandscapeRight = 'landscapeRight',
+}
+
 export type CameraPositionType = 'back' | 'front';
 
-export class AdvancedVideoViewBase extends View {
+export abstract class AdvancedVideoViewBase extends View {
     cameraPosition: CameraPositionType;
     saveToGallery: boolean;
     quality: Quality;
     thumbnailCount: number;
     fill: boolean;
+    outputOrientation: Orientation;
+
+    abstract readonly duration: number;
+    abstract readonly thumbnails: string[];
+
+    public abstract startRecording(): void;
+    public abstract stopRecording(): void;
+    public abstract stopPreview(): void;
+    public abstract toggleCamera(): void;
+    public abstract startPreview(): void;
 
     public static isAvailable(): boolean {
         return false;
@@ -32,22 +50,31 @@ export class AdvancedVideoViewBase extends View {
         return Promise.resolve();
     }
 }
+
+export const outputOrientation = new Property<AdvancedVideoViewBase, string>({
+    name: 'outputOrientation',
+    defaultValue: Orientation.Unknown
+});
+
 export const fillProperty = new Property<AdvancedVideoViewBase, boolean>({
     name: 'fill',
     defaultValue: false
 });
+
 export const thumbnailCountProperty = new Property<AdvancedVideoViewBase, number>({
     name: 'thumbnailCount',
     defaultValue: 1
 });
+
 export const qualityProperty = new Property<AdvancedVideoViewBase, any>({
     name: 'quality',
     defaultValue: Quality.MAX_480P
 });
+
 export const cameraPositionProperty = new Property<AdvancedVideoViewBase,
     CameraPositionType>({
         name: 'cameraPosition',
-        defaultValue: 'back'
+        defaultValue: CameraPosition.BACK
     });
 
 export const saveToGalleryProperty = new Property<AdvancedVideoViewBase,
@@ -61,3 +88,4 @@ cameraPositionProperty.register(AdvancedVideoViewBase);
 saveToGalleryProperty.register(AdvancedVideoViewBase);
 fillProperty.register(AdvancedVideoViewBase);
 thumbnailCountProperty.register(AdvancedVideoViewBase);
+outputOrientation.register(AdvancedVideoViewBase);

--- a/src/advanced/advanced-video-view.common.ts
+++ b/src/advanced/advanced-video-view.common.ts
@@ -31,6 +31,7 @@ export abstract class AdvancedVideoViewBase extends View {
     quality: Quality;
     thumbnailCount: number;
     fill: boolean;
+    torch: boolean;
     outputOrientation: Orientation;
 
     abstract readonly duration: number;
@@ -40,7 +41,10 @@ export abstract class AdvancedVideoViewBase extends View {
     public abstract stopRecording(): void;
     public abstract stopPreview(): void;
     public abstract toggleCamera(): void;
+    public abstract toggleTorch(): void;
     public abstract startPreview(): void;
+
+    public abstract get isTorchAvailable(): boolean;
 
     public static isAvailable(): boolean {
         return false;
@@ -58,6 +62,11 @@ export const outputOrientation = new Property<AdvancedVideoViewBase, string>({
 
 export const fillProperty = new Property<AdvancedVideoViewBase, boolean>({
     name: 'fill',
+    defaultValue: false
+});
+
+export const torchProperty = new Property<AdvancedVideoViewBase, boolean>({
+    name: 'torch',
     defaultValue: false
 });
 
@@ -89,3 +98,4 @@ saveToGalleryProperty.register(AdvancedVideoViewBase);
 fillProperty.register(AdvancedVideoViewBase);
 thumbnailCountProperty.register(AdvancedVideoViewBase);
 outputOrientation.register(AdvancedVideoViewBase);
+torchProperty.register(AdvancedVideoViewBase);

--- a/src/advanced/advanced-video-view.ios.d.ts
+++ b/src/advanced/advanced-video-view.ios.d.ts
@@ -1,9 +1,18 @@
 import '../async-await';
 import { AdvancedVideoViewBase } from './advanced-video-view.common';
+export * from './advanced-video-view.common';
+export declare enum NativeOrientation {
+    Unknown = 0,
+    Portrait = 1,
+    PortraitUpsideDown = 2,
+    LandscapeLeft = 3,
+    LandscapeRight = 4,
+}
 export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     nativeView: UIView;
     _output: AVCaptureMovieFileOutput;
     _file: NSURL;
+    _connection: AVCaptureConnection;
     private session;
     thumbnails: string[];
     _fileName: string;
@@ -15,6 +24,7 @@ export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     onLoaded(): void;
     onUnloaded(): void;
     readonly duration: number;
+    private _setOutputOrientation(orientation);
     private openCamera();
     startRecording(): void;
     stopRecording(): void;

--- a/src/advanced/advanced-video-view.ios.d.ts
+++ b/src/advanced/advanced-video-view.ios.d.ts
@@ -13,6 +13,7 @@ export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     _output: AVCaptureMovieFileOutput;
     _file: NSURL;
     _connection: AVCaptureConnection;
+    _device: AVCaptureDevice;
     private session;
     thumbnails: string[];
     _fileName: string;
@@ -24,6 +25,8 @@ export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     onLoaded(): void;
     onUnloaded(): void;
     readonly duration: number;
+    readonly isTorchAvailable: boolean;
+    toggleTorch(): void;
     private _setOutputOrientation(orientation);
     private openCamera();
     startRecording(): void;

--- a/src/advanced/advanced-video-view.ios.ts
+++ b/src/advanced/advanced-video-view.ios.ts
@@ -1,8 +1,26 @@
 import * as fs from 'tns-core-modules/file-system';
 import { layout } from 'tns-core-modules/ui/core/view';
 import '../async-await';
-import { AdvancedVideoViewBase, CameraPosition, Quality, saveToGalleryProperty } from './advanced-video-view.common';
+import {
+    AdvancedVideoViewBase,
+    CameraPosition,
+    Quality,
+    saveToGalleryProperty,
+    Orientation,
+    outputOrientation,
+} from './advanced-video-view.common';
+
+export * from './advanced-video-view.common';
+
 import { fromObject } from 'tns-core-modules/data/observable';
+
+export enum NativeOrientation {
+    Unknown,
+    Portrait,
+    PortraitUpsideDown,
+    LandscapeLeft,
+    LandscapeRight,
+}
 
 @ObjCClass(AVCaptureFileOutputRecordingDelegate)
 class AVCaptureFileOutputRecordingDelegateImpl extends NSObject
@@ -61,6 +79,7 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
     nativeView: UIView;
     _output: AVCaptureMovieFileOutput;
     _file: NSURL;
+    _connection: AVCaptureConnection;
     private session: AVCaptureSession;
     public thumbnails: string[];
     _fileName: string;
@@ -114,12 +133,50 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
         }
     }
 
+    [outputOrientation.getDefault](): Orientation {
+        if (!this._connection) return Orientation.Unknown;
+        return Orientation[NativeOrientation[this._connection.videoOrientation]];
+    }
+
+    [outputOrientation.setNative](orientation: Orientation) {
+        this._setOutputOrientation(orientation);
+    }
+
     [saveToGalleryProperty.getDefault]() {
         return false;
     }
 
     [saveToGalleryProperty.setNative](save: boolean) {
         return save;
+    }
+
+    private _setOutputOrientation(orientation: Orientation) {
+        let nativeOrientation: number;
+        switch (orientation) {
+            case Orientation.LandscapeLeft:
+                nativeOrientation = NativeOrientation.LandscapeLeft;
+                break;
+            case Orientation.LandscapeRight:
+                nativeOrientation = NativeOrientation.LandscapeRight;
+                break;
+            case Orientation.Portrait:
+                nativeOrientation = NativeOrientation.Portrait;
+                break;
+            case Orientation.PortraitUpsideDown:
+                nativeOrientation = NativeOrientation.PortraitUpsideDown;
+                break;
+            default:
+                nativeOrientation = NativeOrientation.Unknown;
+                break;
+        }
+
+        if (
+            this._connection &&
+            this._connection.supportsVideoOrientation &&
+            nativeOrientation !== NativeOrientation.Unknown
+        ) {
+            this._connection.videoOrientation = nativeOrientation;
+        }
     }
 
     private openCamera(): void {
@@ -150,11 +207,14 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
 
             this._output = AVCaptureMovieFileOutput.alloc().init();
             this._output.movieFragmentInterval = kCMTimeInvalid;
-            let connection = this._output.connectionWithMediaType(AVMediaTypeVideo);
+            this._connection =  this._output.connectionWithMediaType(AVMediaTypeVideo);
+
+            this._setOutputOrientation(this.outputOrientation);
+
             if (this._output.availableVideoCodecTypes.containsObject(AVVideoCodecTypeH264)) {
                 const codec = {};
                 codec[AVVideoCodecKey] = AVVideoCodecTypeH264;
-                this._output.setOutputSettingsForConnection(<any>codec, connection);
+                this._output.setOutputSettingsForConnection(<any>codec, this._connection);
             }
             let format = '.mp4'; // options && options.format === 'default' ? '.mov' : '.' + options.format;
             this._fileName = `VID_${+new Date()}${format}`;

--- a/src/advanced/index.d.ts
+++ b/src/advanced/index.d.ts
@@ -5,10 +5,12 @@ export * from './advanced-video-view.common'
 export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     readonly duration: number;
     readonly thumbnails: string[];
+    readonly isTorchAvailable: boolean;
 
     public startRecording(): void;
     public stopRecording(): void;
     public stopPreview(): void;
     public toggleCamera(): void;
+    public toggleTorch(): void;
     public startPreview(): void;
 }

--- a/src/advanced/index.d.ts
+++ b/src/advanced/index.d.ts
@@ -1,20 +1,14 @@
-import { AdvancedVideoViewBase } from './advanced-video-view.common';
+import { AdvancedVideoViewBase } from './advanced-video-view.common'
+
+export * from './advanced-video-view.common'
 
 export declare class AdvancedVideoView extends AdvancedVideoViewBase {
     readonly duration: number;
     readonly thumbnails: string[];
 
     public startRecording(): void;
-
     public stopRecording(): void;
-
     public stopPreview(): void;
-
     public toggleCamera(): void;
-
     public startPreview(): void;
-
-    public static requestPermissions(explanation?: string): Promise<any>;
-
-    public static isAvailable(): boolean;
 }

--- a/src/package.json
+++ b/src/package.json
@@ -51,8 +51,8 @@
   "homepage": "https://github.com/triniwiz/nativescript-videorecorder",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "tns-core-modules": "^4.0.0",
-    "tns-platform-declarations": "^4.0.0",
+    "tns-core-modules": "^5.0.0",
+    "tns-platform-declarations": "^5.0.0",
     "typescript": "~2.6.0",
     "prompt": "^1.0.0",
     "rimraf": "^2.5.0",

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('co.fitcom:fancycamera:0.4.2'){
+    implementation ('co.fitcom:fancycamera:0.7.0'){
         exclude group: "com.android.support"
     }
 }

--- a/src/typings/android.d.ts
+++ b/src/typings/android.d.ts
@@ -121,6 +121,7 @@ declare namespace co {
         public startRecording(): void;
         public requestPermission(): void;
         public setCameraPosition(param0: number): void;
+        public setCameraOrientation(param0: number): void;
         public onSurfaceTextureAvailable(param0: androidgraphicsSurfaceTexture, param1: number, param2: number): void;
         public onSurfaceTextureSizeChanged(param0: androidgraphicsSurfaceTexture, param1: number, param2: number): void;
         public hasPermission(): boolean;
@@ -130,6 +131,7 @@ declare namespace co {
         public setFile(param0: javaioFile): void;
         public toggleCamera(): void;
         public getCameraPosition(): number;
+        public getCameraOrientation(): number;
         public constructor(param0: androidcontentContext);
         public onSurfaceTextureUpdated(param0: androidgraphicsSurfaceTexture): void;
         public constructor(param0: androidcontentContext, param1: androidutilAttributeSet);
@@ -143,6 +145,16 @@ declare namespace co {
           public getValue(): number;
           public static values(): native.Array<co.fitcom.fancycamera.FancyCamera.CameraPosition>;
           public static valueOf(param0: string): co.fitcom.fancycamera.FancyCamera.CameraPosition;
+        }
+        export class CameraOrientation {
+          public static UNKNOWN: co.fitcom.fancycamera.FancyCamera.CameraOrientation;
+          public static PORTRAIT: co.fitcom.fancycamera.FancyCamera.CameraOrientation;
+          public static PORTRAIT_UPSIDE_DOWN: co.fitcom.fancycamera.FancyCamera.CameraOrientation;
+          public static LANDSCAPE_LEFT: co.fitcom.fancycamera.FancyCamera.CameraOrientation;
+          public static LANDSCAPE_RIGHT: co.fitcom.fancycamera.FancyCamera.CameraOrientation;
+          public getValue(): number;
+          public static values(): native.Array<co.fitcom.fancycamera.FancyCamera.CameraOrientation>;
+          public static valueOf(param0: string): co.fitcom.fancycamera.FancyCamera.CameraOrientation;
         }
         export class Quality {
           public static MAX_480P: co.fitcom.fancycamera.FancyCamera.Quality;


### PR DESCRIPTION
Add two new properties : 

* torch - enable / disable torch, also add helper methods, does not work yet on Android
* outputOrientation - choose orientation of the output video file

outputOrientation is the only way to handle camera orientation when device auto-rotate is disabled.

