### PR TITLE
Update content to be androidX compatible if available

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.pkg.github.com/agregar

--- a/src/advanced/advanced-video-view.android.ts
+++ b/src/advanced/advanced-video-view.android.ts
@@ -48,7 +48,7 @@ export class AdvancedVideoView extends AdvancedVideoViewBase {
     private durationInterval: any;
 
     public static isAvailable() {
-        return app.android.currentContext.getPackageManager().hasSystemFeature(android.content.pm.PackageManager.FEATURE_CAMERA);
+        return app.android.context.getPackageManager().hasSystemFeature(android.content.pm.PackageManager.FEATURE_CAMERA);
     }
 
     public createNativeView() {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nativescript-videorecorder",
-  "version": "3.0.0-beta.2",
+  "name": "@agregar/nativescript-videorecorder",
+  "version": "3.1.0-beta.0",
   "description": "NativeScript videorecording plugin",
   "main": "videorecorder",
   "typings": "index.d.ts",
@@ -19,8 +19,8 @@
     "tslint": "cd .. && tslint \"**/*.ts\" --config tslint.json --exclude \"**/node_modules/**\"",
     "plugin.link": "npm link && cd ../demo && npm link nativescript-videorecorder && cd ../src",
     "plugin.tscwatch": "npm run tsc -- -w",
-    "demo.ios": "npm i && npm run tsc && cd ../demo && tns run ios --syncAllFiles",
-    "demo.android": "npm i && npm run tsc && cd ../demo && tns run android --syncAllFiles",
+    "demo.ios": "npm i && npm run tsc && cd ../demo && tns run ios",
+    "demo.android": "npm i && npm run tsc && cd ../demo && tns run android",
     "demo.reset": "cd ../demo && rimraf platforms",
     "plugin.prepare": "npm run tsc && cd ../demo && tns plugin remove nativescript-videorecorder && tns plugin add ../src",
     "clean": "cd ../demo && rimraf hooks node_modules platforms && cd ../src && rimraf node_modules && npm run plugin.link",
@@ -51,15 +51,20 @@
   "homepage": "https://github.com/triniwiz/nativescript-videorecorder",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "tns-core-modules": "^5.0.0",
-    "tns-platform-declarations": "^5.0.0",
-    "typescript": "~2.6.0",
+    "tns-core-modules": "^6.1.0",
+    "tns-platform-declarations": "^6.1.0",
+    "typescript": "~3.5.3",
     "prompt": "^1.0.0",
     "rimraf": "^2.5.0",
-    "tslint": "^5.0.0"
+    "tslint": "^5.11.0"
   },
   "dependencies": {
     "nativescript-permissions": "^1.0.0"
   },
-  "bootstrapper": "nativescript-plugin-seed"
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Agregar/nativescript-videorecorder.git"
+  },
+  "bootstrapper": "nativescript-plugin-seed",
+  "publishConfig": { "registry": "https://npm.pkg.github.com" }
 }

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -4,6 +4,15 @@ import * as platform from 'tns-core-modules/platform';
 import * as utils from 'tns-core-modules/utils/utils';
 import './async-await';
 
+let androidSupport = null;
+declare var androidx: any;
+
+if (android.support && android.support.v4) {
+  androidSupport = android.support.v4;
+} else if (androidx && androidx.core) {
+  androidSupport = androidx.core;
+}
+
 import {
   CameraPosition,
   Options,
@@ -31,7 +40,7 @@ export class VideoRecorder extends VideoRecorderCommon {
   }
 
   public static isAvailable() {
-    return app.android.currentContext
+    return app.android.context
       .getPackageManager()
       .hasSystemFeature(android.content.pm.PackageManager.FEATURE_CAMERA);
   }
@@ -82,7 +91,7 @@ export class VideoRecorder extends VideoRecorderCommon {
             android.os.Environment.DIRECTORY_DCIM
           ).getAbsolutePath() + '/Camera';
       } else {
-        path = app.android.currentContext
+        path = app.android.context
           .getExternalFilesDir(null)
           .getAbsolutePath();
       }
@@ -91,7 +100,7 @@ export class VideoRecorder extends VideoRecorderCommon {
 
       if (sdkVersionInt >= 21) {
         tempPictureUri = (<any>(
-          android.support.v4.content
+          androidSupport.content
         )).FileProvider.getUriForFile(
           app.android.foregroundActivity, // or app.android.currentContext ??
           `${pkgName}.provider`,

--- a/src/videorecorder.android.ts
+++ b/src/videorecorder.android.ts
@@ -9,7 +9,8 @@ declare var androidx: any;
 
 if (android.support && android.support.v4) {
   androidSupport = android.support.v4;
-} else if (androidx && androidx.core) {
+}
+if (androidx && androidx.core) {
   androidSupport = androidx.core;
 }
 


### PR DESCRIPTION
Fixes #71 - Switches to androidX libraries or support libraries depending on availability
Fixes #69 Fixes #70 - uses android.context instead of deprecated android.currentContext